### PR TITLE
Add `netdata_healthcheck_target` configuration

### DIFF
--- a/netdata/DOCS.md
+++ b/netdata/DOCS.md
@@ -75,6 +75,12 @@ Refer to
 
 Note that `lm-sensors` comes preinstalled already.
 
+### Option: `netdata_healthcheck_target`
+
+Change or disable the default docker health check from Netdata.
+Refer to
+<https://learn.netdata.cloud/docs/installing/docker#health-checks>.
+
 ## Configuring the [Netdata integration](https://www.home-assistant.io/integrations/netdata/)
 
 ```yaml

--- a/netdata/DOCS.md
+++ b/netdata/DOCS.md
@@ -77,7 +77,7 @@ Note that `lm-sensors` comes preinstalled already.
 
 ### Option: `netdata_healthcheck_target`
 
-Change or disable the default docker health check from Netdata.
+Allows to control how the docker health checks from Netdata run. For example: `cli`.
 Refer to
 <https://learn.netdata.cloud/docs/installing/docker#health-checks>.
 

--- a/netdata/config.yaml
+++ b/netdata/config.yaml
@@ -18,12 +18,14 @@ options:
   netdata_claim_token: ""
   netdata_claim_rooms: ""
   netdata_extra_deb_packages: ""
+  netdata_healthcheck_target: ""
 schema:
   hostname: str
   netdata_claim_url: str
   netdata_claim_token: str
   netdata_claim_rooms: str
   netdata_extra_deb_packages: str
+  netdata_healthcheck_target: str
 startup: services
 ingress: true
 ingress_port: 19999

--- a/netdata/rootfs/run.sh
+++ b/netdata/rootfs/run.sh
@@ -102,10 +102,12 @@ get_config netdata_claim_url
 get_config netdata_claim_token
 get_config netdata_claim_rooms
 get_config netdata_extra_deb_packages
+get_config netdata_healthcheck_target
 export NETDATA_CLAIM_URL="${netdata_claim_url}"
 export NETDATA_CLAIM_TOKEN="${netdata_claim_token}"
 export NETDATA_CLAIM_ROOMS="${netdata_claim_rooms}"
 export NETDATA_EXTRA_DEB_PACKAGES="${netdata_extra_deb_packages}"
+export NETDATA_HEALTHCHECK_TARGET="${netdata_healthcheck_target}"
 
 get_config hostname
 hostname "${hostname}"


### PR DESCRIPTION
Add configuration `netdata_healthcheck_target` that is passed to `NETDATA_HEALTHCHECK_TARGET` environment variable for netdata docker image to control healthcheck: https://learn.netdata.cloud/docs/installing/docker#health-checks