### PR TITLE
Fix cgroups metrics not showing up (second time)

### DIFF
--- a/netdata/CHANGELOG.md
+++ b/netdata/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 [Click here to view the release notes of Netdata itself](https://github.com/netdata/netdata/releases).
 
+### 2.3.1-addon.2
+
+- Fix cgroup metrics not showing because of `/host/sys/fs/cgroup` mount not working
+
 ### 2.3.1-addon.1
 
 - Hotfix for the add-on not being removed after stopping it

--- a/netdata/config.yaml
+++ b/netdata/config.yaml
@@ -1,6 +1,6 @@
 # https://developers.home-assistant.io/docs/add-ons/configuration#add-on-config
 name: Netdata
-version: v2.3.1-addon.1
+version: v2.3.1-addon.2
 slug: netdata
 description:
   Monitor your servers, containers, and applications, in high-resolution and in

--- a/netdata/rootfs/opt/netdata-hass-addon/run.sh
+++ b/netdata/rootfs/opt/netdata-hass-addon/run.sh
@@ -60,12 +60,16 @@ if ! mountpoint --quiet /host/etc/os-release; then
   # Mount /proc from host to /host/proc as readonly with nsenter
   mkdir -p /host/proc
   nsenter --target 1 --mount -- \
-    mount --bind --read-only /proc "${container_root_on_host}/host/proc"
+    mount --rbind --read-only /proc "${container_root_on_host}/host/proc"
+  nsenter --target 1 --mount -- \
+    mount --make-slave "${container_root_on_host}/host/proc"
 
   # Same for /sys
   mkdir -p /host/sys
   nsenter --target 1 --mount -- \
-    mount --bind --read-only /sys "${container_root_on_host}/host/sys"
+    mount --rbind --read-only /sys "${container_root_on_host}/host/sys"
+  nsenter --target 1 --mount -- \
+    mount --make-slave "${container_root_on_host}/host/sys"
 
   # Same for /etc/passwd
   mkdir -p /host/etc

--- a/netdata/rootfs/opt/netdata-hass-addon/run.sh
+++ b/netdata/rootfs/opt/netdata-hass-addon/run.sh
@@ -60,16 +60,14 @@ if ! mountpoint --quiet /host/etc/os-release; then
   # Mount /proc from host to /host/proc as readonly with nsenter
   mkdir -p /host/proc
   nsenter --target 1 --mount -- \
-    mount --rbind --read-only /proc "${container_root_on_host}/host/proc"
-  nsenter --target 1 --mount -- \
-    mount --make-slave "${container_root_on_host}/host/proc"
+    mount --bind --read-only /proc "${container_root_on_host}/host/proc"
 
-  # Same for /sys
+  # Same for /sys and /sys/fs/cgroup
   mkdir -p /host/sys
   nsenter --target 1 --mount -- \
-    mount --rbind --read-only /sys "${container_root_on_host}/host/sys"
+    mount --bind --read-only /sys "${container_root_on_host}/host/sys"
   nsenter --target 1 --mount -- \
-    mount --make-slave "${container_root_on_host}/host/sys"
+    mount --bind --read-only /sys/fs/cgroup "${container_root_on_host}/host/sys/fs/cgroup"
 
   # Same for /etc/passwd
   mkdir -p /host/etc

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -34,3 +34,34 @@ else
     echo "File /host/etc/os-release in the container does not match the host" >&2
     exit 1
 fi
+
+if container_cgroup_max_depth=$(docker compose exec -T netdata cat /host/sys/fs/cgroup/cgroup.max.depth); then
+    echo "File /host/sys/fs/cgroup/cgroup.max.depth exists in the container" >&2
+else
+    echo "File /host/sys/fs/cgroup/cgroup.max.depth does not exist in the container" >&2
+    exit 1
+fi
+
+host_cgroup_max_depth=$(cat /sys/fs/cgroup/cgroup.max.depth)
+if [[ "${container_cgroup_max_depth}" == "${host_cgroup_max_depth}" ]]; then
+    echo "File /host/sys/fs/cgroup/cgroup.max.depth in the container matches the host" >&2
+else
+    echo "File /host/sys/fs/cgroup/cgroup.max.depth in the container does not match the host" >&2
+    exit 1
+fi
+
+if docker compose down; then
+    echo "Container stopped and removed successfully" >&2
+else
+    echo "Container failed to stop and remove" >&2
+    exit 1
+fi
+
+# There is a bug where the container can mess with the host cgroups upon removal,
+# this should help catch it
+if new_host_cgroup_max_depth=$(cat /sys/fs/cgroup/cgroup.max.depth) && [[ "${new_host_cgroup_max_depth}" == "${host_cgroup_max_depth}" ]]; then
+    echo "Host cgroup max depth is unchanged after container removal" >&2
+else
+    echo "Host cgroup max depth is changed after container removal" >&2
+    exit 1
+fi


### PR DESCRIPTION
It was causing a bug where the add-on container could not be removed from host, because of "device or resource busy".

Unfortunately, I was not able to automate this test, which means it has to be tested manually in a real instance.

Closes #57
